### PR TITLE
Add direct disc launch support for NSP forwarders

### DIFF
--- a/launcher/source/main.cpp
+++ b/launcher/source/main.cpp
@@ -6735,18 +6735,30 @@ int main(int argc, char **argv){
   g_localization.SetLanguage(storeGet(g_global,"Wrapper/Language","system"));
   applyLauncherAppearance();
   uiAudioSetEnabled(strcmp(storeGet(g_global,"Wrapper/UiSounds","true"),"false")!=0);
+
+  // Standard NSP forwarders pass the selected disc path as argv[1]. Detect
+  // that mode before starting the normal library/storage UI pipeline so a
+  // direct launch cannot flash the grid or a storage-wait screen.
+  std::string positionalForwarderPath;
+  if(argc>=2&&argv[1]&&argv[1][0]){
+    const std::string candidate=normalizeLocationPath(argv[1]);
+    if(!candidate.empty()&&hasDiscExt(candidate.c_str())) positionalForwarderPath=candidate;
+  }
+  const bool silentDirectForwarder=!positionalForwarderPath.empty();
+
   startCoverDecodeWorker();
   std::vector<std::string> gamePaths=loadGameSources();
   bool hasUsbSource=hasConfiguredUsbSource(gamePaths);
   SwitchStorage::SetUsbStatusCallback(usbStatusWake);
   LauncherUpdate_SetWakeCallback(usbStatusWake,nullptr);
-  startUsbInitialization();
-  startAutoMountShares();
+  const bool directForwarderUsesUsb=silentDirectForwarder&&isUsbStoragePath(positionalForwarderPath);
+  if(!silentDirectForwarder||directForwarderUsesUsb) startUsbInitialization();
+  if(!silentDirectForwarder) startAutoMountShares();
   auto usbSnapshot=SwitchStorage::GetUsbSnapshot();
   uint64_t usbGeneration=usbSnapshot.generation;
   auto usbLocations=usbSnapshot.locations;
   refreshConfiguredUsbSources(gamePaths);
-  scanGames(gamePaths);
+  if(!silentDirectForwarder) scanGames(gamePaths);
   Uint32 usbRefreshAt=0,smbRefreshAt=0;
   std::vector<std::string> smbPendingSources;
   const uint64_t startupUsbGeneration=SwitchStorage::UsbStatusGeneration();
@@ -6780,12 +6792,54 @@ int main(int argc, char **argv){
     running=false;
   };
 
-  bool forwarderRequested=false,forwarderMatched=false;
-  std::string forwarderKey;
-  for(int argument=1;argument+1<argc;argument++) if(!strcmp(argv[argument],"-g")){
+  auto prepareDirectForwarderGame=[&](const std::string &directPath) -> bool {
+    struct stat info{};
+    if(stat(directPath.c_str(),&info)!=0||!S_ISREG(info.st_mode)) return false;
+
+    Game game;
+    game.path=directPath;
+    const size_t slash=directPath.find_last_of("/\\");
+    game.file=slash==std::string::npos?directPath:directPath.substr(slash+1);
+    game.sourceRoot=slash==std::string::npos?std::string{}:directPath.substr(0,slash);
+    game.storageId=storageIdForSource(game.sourceRoot.empty()?directPath:game.sourceRoot);
+    game.legacyKey=sanitize(game.file);
+    game.pathKey=makeLegacyPathKey(game.file,game.path);
+    game.fileSize=static_cast<uint64_t>(info.st_size);
+    game.modified=static_cast<long long>(info.st_mtime);
+    game.added=game.modified;
+
+    // Reuse the persisted fingerprint when the same file is unchanged;
+    // otherwise sample the disc exactly like the normal library scanner.
+    for(const auto &record:g_libraryIdentities){
+      if(pathIdentity(record.canonicalPath)==pathIdentity(game.path)&&
+         record.fileSize==game.fileSize&&record.modified==game.modified){
+        game.fingerprint=record.fingerprint;
+        break;
+      }
+    }
+    if(game.fingerprint.empty()) game.fingerprint=fingerprintGameFile(game.path,game.fileSize);
+    if(game.fingerprint.empty()) return false;
+    assignStableIdentity(game);
+    game.legacyUnique=false;
+    game.played=atoll(gameStoreGet(g_recent,game,"0"));
+    game.hasCfg=gameFileExists(GAMECFG_DIR,game,".ini");
+    selectGame(game);
+    return true;
+  };
+
+  bool forwarderRequested=silentDirectForwarder;
+  bool forwarderMatched=false;
+  bool forwarderDirectPath=silentDirectForwarder;
+  std::string forwarderKey=positionalForwarderPath;
+  auto findForwarderGame=[&]() -> Game* { return findGameByKey(forwarderKey); };
+
+  if(forwarderDirectPath) forwarderMatched=prepareDirectForwarderGame(forwarderKey);
+
+  // Preserve NaGaa's built-in -g <gameKey> behavior unchanged.
+  if(!forwarderRequested) for(int argument=1;argument+1<argc;argument++) if(!strcmp(argv[argument],"-g")){
     forwarderRequested=true;
     forwarderKey=argv[argument+1];
-    if(Game *game=findGameByKey(forwarderKey)){ selectGame(*game); forwarderMatched=true; }
+    if(Game *game=findForwarderGame()){ selectGame(*game); forwarderMatched=true; }
     break;
   }
   if(!forwarderRequested&&g_griddbReady&&
@@ -6813,9 +6867,13 @@ int main(int argc, char **argv){
       scanAdditionalGames(smbPendingSources);
       smbPendingSources.clear();
     }
-    if(forwarderPending) if(Game *game=findGameByKey(forwarderKey)){
-      selectGame(*game);
-      forwarderPending=false;
+    if(forwarderPending){
+      if(forwarderDirectPath){
+        if(prepareDirectForwarderGame(forwarderKey)) forwarderPending=false;
+      } else if(Game *game=findForwarderGame()){
+        selectGame(*game);
+        forwarderPending=false;
+      }
     }
     if(hasUsbSource){
       const Uint32 now=SDL_GetTicks();
@@ -6858,9 +6916,13 @@ int main(int argc, char **argv){
         sel=0; top=0;
         if(!selected.empty()) for(int index=0;index<(int)g_visibleGames.size();index++)
           if(visibleGame(index)&&visibleGame(index)->key==selected){ sel=index; break; }
-        if(forwarderPending) if(Game *game=findGameByKey(forwarderKey)){
-          selectGame(*game);
-          forwarderPending=false;
+        if(forwarderPending){
+          if(forwarderDirectPath){
+            if(prepareDirectForwarderGame(forwarderKey)) forwarderPending=false;
+          } else if(Game *game=findForwarderGame()){
+            selectGame(*game);
+            forwarderPending=false;
+          }
         }
       }
       if(!running) break;
@@ -6885,8 +6947,10 @@ int main(int argc, char **argv){
         }
       }
       if(!running) break;
-      renderUsbForwarderWait();
-    waitForNextFrame();
+      // Raw positional forwarders remain visually silent while waiting for
+      // their storage path. Built-in -g shortcuts keep NaGaa's wait screen.
+      if(!forwarderDirectPath) renderUsbForwarderWait();
+      waitForNextFrame();
       continue;
     }
     GLay layout=gridLayout(); int cols=layout.cols; rows=layout.rows;


### PR DESCRIPTION
Dear NaGaa95,

First of all, thank you very much for all the work you have put into NetherSX2_nx and your other Nintendo Switch ports. I have been using them quite a lot and really appreciate having these emulators available natively on the Switch!

I wanted to contribute a small improvement that I have been working on and testing on my own console.

## Summary

This adds support for standard NSP forwarders that pass the selected PS2 disc path directly through `argv[1]`.

With this change, launching a game from an NSP forwarder goes directly into the selected game without first displaying the NetherSX2 launcher grid or a storage waiting screen.

The normal launcher behavior remains unchanged when NetherSX2_nx is opened normally.

## What changes

When NetherSX2_nx receives a valid PS2 disc path directly in `argv[1]`, the launcher detects this mode early during startup and prepares that game for direct launch.

The implementation:

- Accepts a disc path supplied directly through `argv[1]`.
- Checks that the argument has a supported disc extension before treating it as a direct forwarder launch.
- Builds the game identity directly from the selected disc file.
- Reuses the existing fingerprint and stable-identity mechanisms used by the normal library.
- Reuses persisted fingerprint information when the same disc file has not changed.
- Avoids scanning the normal game library when it is not needed.
- Avoids starting unrelated SMB auto-mount work for a positional direct forwarder.
- Only initializes USB when the forwarded game itself requires USB storage.
- Avoids displaying the launcher grid before the game starts.
- Avoids displaying the USB waiting screen for positional direct forwarders.

## Existing forwarder behavior preserved

The existing:

`-g <gameKey>`

mechanism is intentionally preserved.

This change only adds support for the common forwarder format where the game path itself is supplied as the positional argument:

`argv[1]`

The existing `-g <gameKey>` workflow therefore remains available and keeps its normal behavior.

## Example

A standard NSP forwarder can launch NetherSX2_nx with something equivalent to:

    NetherSX2_nx.nro "sdmc:/roms/ps2/Game.iso"

NetherSX2_nx detects the disc path and prepares that game directly instead of opening the normal game-selection interface first.

## Testing

I have manually tested this behavior on my own Nintendo Switch using NSP forwarders.

I personally verified that:

- Direct forwarders open the requested PS2 game correctly.
- The launcher/grid is not displayed before the game.
- The disc path received through `argv` is respected.
- Normal NetherSX2_nx startup still opens the launcher normally.
- Existing per-game configuration behavior remains available.
- The existing `-g <gameKey>` mechanism is preserved.

The resulting build has been tested by me on real hardware and everything is working correctly in my tests.

## Scope of this PR

I have intentionally kept the change localized.

Only:

`launcher/source/main.cpp`

is modified.

The change is based directly on the current upstream `main` commit:

`a61915517087a1b2292068ecd747f0813870966f`

which includes the upstream USB Fix.

The diff contains:

- 79 additions
- 15 deletions
- no unrelated files or changes

No version bump is required.

My intention was to make the smallest practical change needed to support standard positional NSP forwarders while preserving the existing launcher and `-g <gameKey>` behavior.

## AI disclosure

I worked on this fix together with ChatGPT. ChatGPT helped me analyze the launcher flow, develop and review the proposed changes, and prepare the technical documentation for this Pull Request.

However, I personally reviewed the final result and performed the functional validation myself.

I manually tested the resulting build on my own Nintendo Switch using real NSP forwarders, and I personally verified that the intended behavior works correctly on real hardware.

So while ChatGPT was actively involved in the analysis and development process, the final review and real-hardware validation were performed by me.

This Pull Request is also being submitted from my own GitHub account.

Thanks again for your work on NetherSX2_nx. I hope this improvement can be useful for the official version as well.

Thanks in advance!

Warm regards,  

Willsito